### PR TITLE
Make the tunnel client work under NativeAOT

### DIFF
--- a/src/Tunnelite.Sdk/HttpTunnel/HttpTunnelClient.cs
+++ b/src/Tunnelite.Sdk/HttpTunnel/HttpTunnelClient.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.AspNetCore.SignalR.Client;
+using Nerdbank.MessagePack;
+using Nerdbank.MessagePack.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System.Buffers;
@@ -43,7 +45,12 @@ public class HttpTunnelClient : ITunnelClient
 
         Connection = new HubConnectionBuilder()
             .WithUrl($"{tunnel.PublicUrl}/wsshttptunnel?clientId={tunnel.ClientId}")
-            .AddMessagePackProtocol()
+            .AddMessagePackProtocol(
+                TunneliteWitness.GeneratedTypeShapeProvider,
+                new MessagePackSerializer
+                {
+                    Converters = [new GuidAsStringConverter(), new WebSocketMessageTypeConverter()],
+                })
             .ConfigureLogging(logging =>
             {
                 if (logLevel.HasValue)
@@ -211,7 +218,7 @@ public class HttpTunnelClient : ITunnelClient
     {
         try
         {
-            await foreach (var chunk in Connection.StreamAsync<(ReadOnlyMemory<byte> Data, WebSocketMessageType Type)>("StreamIncomingWsAsync", wsConnection, cancellationToken: cancellationToken))
+            await foreach (var chunk in Connection.StreamAsync<WsChunk>("StreamIncomingWsAsync", wsConnection, cancellationToken: cancellationToken))
             {
                 if (webSocket.State == WebSocketState.Open)
                 {
@@ -241,7 +248,7 @@ public class HttpTunnelClient : ITunnelClient
         await Connection.InvokeAsync("StreamOutgoingWsAsync", StreamLocalWsAsync(localWebSocket, wsConnection, cancellationToken), wsConnection, cancellationToken: cancellationToken);
     }
 
-    private async IAsyncEnumerable<(ReadOnlyMemory<byte>, WebSocketMessageType)> StreamLocalWsAsync(WebSocket webSocket, WsConnection wsConnection, [EnumeratorCancellation] CancellationToken cancellationToken)
+    private async IAsyncEnumerable<WsChunk> StreamLocalWsAsync(WebSocket webSocket, WsConnection wsConnection, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         const int chunkSize = 32 * 1024;
 
@@ -258,7 +265,7 @@ public class HttpTunnelClient : ITunnelClient
                     break;
                 }
 
-                yield return (new ReadOnlyMemory<byte>(buffer, 0, result.Count), result.MessageType);
+                yield return new WsChunk(buffer[..result.Count], result.MessageType);
             }
         }
         finally
@@ -321,7 +328,7 @@ public class HttpTunnelClient : ITunnelClient
             cancellationToken: cancellationToken);
     }
 
-    private async IAsyncEnumerable<ReadOnlyMemory<byte>> StreamLocalSseAsync(
+    private async IAsyncEnumerable<byte[]> StreamLocalSseAsync(
         HttpResponseMessage response,
         SseConnection sseConnection,
         [EnumeratorCancellation] CancellationToken cancellationToken)
@@ -336,7 +343,7 @@ public class HttpTunnelClient : ITunnelClient
             int bytesRead;
             while ((bytesRead = await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken)) > 0)
             {
-                yield return new ReadOnlyMemory<byte>(buffer, 0, bytesRead);
+                yield return buffer[..bytesRead];
             }
         }
         finally
@@ -357,9 +364,9 @@ public class HttpTunnelClient : ITunnelClient
         {
             try
             {
-                var response = await ServerHttpClient.PostAsJsonAsync($"{Tunnel.PublicUrl}/tunnelite/tunnel", tunnel);
+                var response = await ServerHttpClient.PostAsJsonAsync($"{Tunnel.PublicUrl}/tunnelite/tunnel", tunnel, TunneliteJsonContext.Default.HttpTunnelRequest);
 
-                tunnelResponse = await response.Content.ReadFromJsonAsync<HttpTunnelResponse?>();
+                tunnelResponse = await response.Content.ReadFromJsonAsync(TunneliteJsonContext.Default.HttpTunnelResponse);
 
                 if (!response.IsSuccessStatusCode)
                 {

--- a/src/Tunnelite.Sdk/HttpTunnel/WsChunk.cs
+++ b/src/Tunnelite.Sdk/HttpTunnel/WsChunk.cs
@@ -1,0 +1,33 @@
+#nullable disable
+using Nerdbank.MessagePack;
+using System.Net.WebSockets;
+
+namespace Tunnelite.Sdk;
+
+/// <summary>
+/// A chunk of WebSocket traffic on its way through the tunnel.
+/// </summary>
+/// <remarks>
+/// The server binds this as a <c>(ReadOnlyMemory&lt;byte&gt;, WebSocketMessageType)</c> tuple, which
+/// MessagePack writes as a two element array - hence the explicit keys. It is a class rather than that
+/// tuple because SignalR resolves the type of a stream item at runtime, and under NativeAOT that
+/// resolution only works for reference types.
+/// </remarks>
+public class WsChunk
+{
+    public WsChunk()
+    {
+    }
+
+    public WsChunk(byte[] data, WebSocketMessageType type)
+    {
+        Data = data;
+        Type = type;
+    }
+
+    [Key(0)]
+    public byte[] Data { get; set; }
+
+    [Key(1)]
+    public WebSocketMessageType Type { get; set; }
+}

--- a/src/Tunnelite.Sdk/Serialization/TunneliteJsonContext.cs
+++ b/src/Tunnelite.Sdk/Serialization/TunneliteJsonContext.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace Tunnelite.Sdk;
+
+/// <summary>
+/// Source generated serializer for the tunnel registration call, so the client does not need
+/// reflection-based JSON at runtime.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(HttpTunnelRequest))]
+[JsonSerializable(typeof(HttpTunnelResponse))]
+internal partial class TunneliteJsonContext : JsonSerializerContext
+{
+}

--- a/src/Tunnelite.Sdk/Serialization/TunneliteWitness.cs
+++ b/src/Tunnelite.Sdk/Serialization/TunneliteWitness.cs
@@ -1,0 +1,43 @@
+using Nerdbank.MessagePack;
+using PolyType;
+using System.Net.WebSockets;
+
+namespace Tunnelite.Sdk;
+
+/// <summary>
+/// Type shapes for everything that crosses the tunnel hub. SignalR resolves argument and stream item
+/// types at runtime, so an AOT build needs the shapes generated up front rather than discovered by
+/// reflection.
+/// </summary>
+[GenerateShapeFor<HttpConnection>]
+[GenerateShapeFor<WsConnection>]
+[GenerateShapeFor<SseConnection>]
+[GenerateShapeFor<TcpConnection>]
+[GenerateShapeFor<TcpTunnelRequest>]
+[GenerateShapeFor<TcpTunnelResponse>]
+[GenerateShapeFor<WsChunk>]
+[GenerateShapeFor<byte[]>]
+[GenerateShapeFor<string>]
+internal partial class TunneliteWitness;
+
+/// <summary>
+/// Keeps the payload encoding identical to the one MessagePack-CSharp produces on the server:
+/// Guids as their 36 character string form rather than an extension, and enums as their names.
+/// </summary>
+internal sealed class GuidAsStringConverter : MessagePackConverter<Guid>
+{
+    public override Guid Read(ref MessagePackReader reader, SerializationContext context) =>
+        reader.TryReadNil() ? Guid.Empty : Guid.Parse(reader.ReadString()!);
+
+    public override void Write(ref MessagePackWriter writer, in Guid value, SerializationContext context) =>
+        writer.Write(value.ToString());
+}
+
+internal sealed class WebSocketMessageTypeConverter : MessagePackConverter<WebSocketMessageType>
+{
+    public override WebSocketMessageType Read(ref MessagePackReader reader, SerializationContext context) =>
+        Enum.Parse<WebSocketMessageType>(reader.ReadString()!);
+
+    public override void Write(ref MessagePackWriter writer, in WebSocketMessageType value, SerializationContext context) =>
+        writer.Write(value.ToString());
+}

--- a/src/Tunnelite.Sdk/TcpTunnel/TcpTunnelClient.cs
+++ b/src/Tunnelite.Sdk/TcpTunnel/TcpTunnelClient.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.AspNetCore.SignalR.Client;
+using Nerdbank.MessagePack;
+using Nerdbank.MessagePack.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System.Buffers;
@@ -35,7 +37,12 @@ public class TcpTunnelClient : ITunnelClient
 
         Connection = new HubConnectionBuilder()
             .WithUrl($"{Tunnel.PublicUrl}/wsstcptunnel?clientId={tunnel.ClientId}")
-            .AddMessagePackProtocol()
+            .AddMessagePackProtocol(
+                TunneliteWitness.GeneratedTypeShapeProvider,
+                new MessagePackSerializer
+                {
+                    Converters = [new GuidAsStringConverter(), new WebSocketMessageTypeConverter()],
+                })
             .ConfigureLogging(logging =>
             {
                 if (logLevel.HasValue)
@@ -146,7 +153,7 @@ public class TcpTunnelClient : ITunnelClient
     {
         try
         {
-            var incomingTcpStream = Connection.StreamAsync<ReadOnlyMemory<byte>>("StreamIncomingAsync", tcpConnection, cancellationToken: cancellationToken);
+            var incomingTcpStream = Connection.StreamAsync<byte[]>("StreamIncomingAsync", tcpConnection, cancellationToken: cancellationToken);
 
             var localTcpStream = localClient.GetStream();
 
@@ -178,7 +185,7 @@ public class TcpTunnelClient : ITunnelClient
         await Connection.InvokeAsync("StreamOutgoingAsync", StreamLocalTcpAsync(localClient, tcpConnection, cancellationToken), tcpConnection, cancellationToken: cancellationToken);
     }
 
-    private async IAsyncEnumerable<ReadOnlyMemory<byte>> StreamLocalTcpAsync(TcpClient localClient, TcpConnection tcpConnection, [EnumeratorCancellation] CancellationToken cancellationToken)
+    private async IAsyncEnumerable<byte[]> StreamLocalTcpAsync(TcpClient localClient, TcpConnection tcpConnection, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         const int chunkSize = 16 * 1024;
 
@@ -192,7 +199,7 @@ public class TcpTunnelClient : ITunnelClient
             while (!cancellationToken.IsCancellationRequested &&
                 (bytesRead = await tcpStream.ReadAsync(buffer, cancellationToken)) > 0)
             {
-                yield return new ReadOnlyMemory<byte>(buffer, 0, bytesRead);
+                yield return buffer[..bytesRead];
             }
         }
         finally

--- a/src/Tunnelite.Sdk/Tunnelite.Sdk.csproj
+++ b/src/Tunnelite.Sdk/Tunnelite.Sdk.csproj
@@ -26,15 +26,17 @@
 		</None>
 	</ItemGroup>
 
+	<ItemGroup>
+		<PackageReference Include="Nerdbank.MessagePack.SignalR" Version="1.3.85" />
+	</ItemGroup>
+
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.31" />
-		<PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.31" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
 		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.12" />
-		<PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.12" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.12" />
 	</ItemGroup>
 


### PR DESCRIPTION
Fixes #5.

Publishing `Tunnelite.Client` with `-p:PublishAot=true` already succeeded before this change, but the resulting binary failed at runtime — it connected, then failed to register the tunnel, and WebSocket/TCP connections were closed with zero bytes transferred.

**The server is untouched, the wire format is unchanged and the `net8.0` targets stay put**, so an AOT client still talks to an unmodified server — including the one behind tunnelite.com.

## What was broken

1. **Tunnel registration** used the reflection-based `PostAsJsonAsync` / `ReadFromJsonAsync<T>` overloads: `Reflection-based serialization has been disabled for this application`.

2. **The MessagePack hub protocol.** `Microsoft.AspNetCore.SignalR.Protocols.MessagePack` resolves payload types through MessagePack-CSharp's `ContractlessStandardResolver`, which emits IL: `PlatformNotSupportedException: Dynamic code generation is not supported on this platform`.

3. **Struct stream payloads.** SignalR binds hub arguments and stream items from a runtime `Type`, which ends up in `MethodInfo.MakeGenericMethod`. Under NativeAOT that only resolves for reference types, so `ReadOnlyMemory<byte>` (TCP/SSE) and `(ReadOnlyMemory<byte>, WebSocketMessageType)` (WebSocket) failed to bind and tore the hub connection down with a `StreamBindingFailureMessage`.

## The fix

`Nerdbank.MessagePack.SignalR` is a hub protocol built for exactly this: it takes a PolyType shape provider instead of discovering types at runtime, so nothing is emitted and nothing is reflected over. It replaces `Microsoft.AspNetCore.SignalR.Protocols.MessagePack` in `Tunnelite.Sdk`, and the SDK ends up with **no hand-written serialization at all** — the types are simply listed:

```csharp
[GenerateShapeFor<HttpConnection>]
[GenerateShapeFor<WsConnection>]
[GenerateShapeFor<SseConnection>]
...
internal partial class TunneliteWitness;
```

Two small converters keep the encoding byte-identical to what the server produces. Neither is Nerdbank's doing — both are conventions MessagePack-CSharp applies on top of the protocol spec:

- **Guid** — MessagePack-CSharp writes the 36 character string (`D924…`); Nerdbank.MessagePack defaults to a compact extension (`D802…`).
- **WebSocketMessageType** — SignalR puts `DynamicEnumAsStringResolver` in front of its chain, so enums travel as names; Nerdbank.MessagePack writes the value.

Point 3 is not fixed by the protocol swap, because the `MakeGenericMethod` call that binds stream items lives in SignalR's own client (`HubConnection.LaunchStreams`) rather than in the protocol. So `ReadOnlyMemory<byte>` becomes `byte[]` — MessagePack encodes both as `bin`, so the bytes do not change — and the WebSocket tuple becomes `WsChunk`, whose `[Key]`s put it in the same two element array.

I did try keeping the original types and just declaring shapes for them (`[GenerateShapeFor<ReadOnlyMemory<byte>>]`, `[GenerateShapeFor<(ReadOnlyMemory<byte>, WebSocketMessageType)>]`). PolyType generates both and it compiles cleanly, but at runtime the upload stream completes with zero items and **no exception is raised anywhere** — the WebSocket tunnel just transfers nothing and the TCP tunnel hangs. Worth knowing, because it is the kind of failure that looks like a network problem rather than a build problem.

Dropping `Microsoft.AspNetCore.SignalR.Protocols.MessagePack` also drops the [GHSA-f8h2-vmm9-qhj6](https://github.com/advisories/GHSA-f8h2-vmm9-qhj6) advisory the SDK has been carrying.

## Verification

osx-arm64 AOT build on the `net8.0` target, against an unmodified `Tunnelite.Server`:

| Path | Result |
| --- | --- |
| HTTP GET | ok |
| HTTP POST with body | ok |
| SSE streaming | ok |
| WebSocket, bidirectional | ok |
| TCP tunnel, 200 KB file | ok, SHA-1 matches |
| Existing JIT build | no regression |

Resulting binary is ~17 MB, starts in ~5 ms, and needs no .NET runtime installed.

## Why this one, and what else was tried

I went down several other roads first. Branches are left up in case you want to compare rather than take my word for it.

| Approach | Result |
| --- | --- |
| **Nerdbank.MessagePack.SignalR** — this PR | ✅ 92 lines, none of it serializer code |
| [Hand-written MessagePack formatters](https://github.com/cristipufu/tunnelite/compare/master...naratteu:tunnelite:plan-b-handwritten-formatters) | ⚠️ works — 382 lines of formatters to maintain by hand |
| [`mpc`, the MessagePack v2 generator](https://github.com/cristipufu/tunnelite/compare/master...naratteu:tunnelite:plan-c-mpc-codegen) | ⚠️ works — but ~900 lines of checked-in generated code, a tool manifest and an MSBuild target, and it silently writes enums as ints where SignalR writes names |
| MessagePack v3's source generator | ❌ v3 disables its own non-generic serialization path under NativeAOT (`MessagePackWriter/Reader overload is not supported in MessagePackSerializer.NonGenerics`) — exactly the path SignalR binds through. Worse than v2 here. SignalR 10.0.12 still pins MessagePack 2.5.302 anyway |
| JSON hub protocol + `JsonSerializerContext` | ❌ the WebSocket hub method binds `IAsyncEnumerable<(ReadOnlyMemory<byte>, WebSocketMessageType)>` and System.Text.Json cannot bind a ValueTuple — needs a server change, and base64 payloads are a poor trade for a tunnel |

The deciding factor is that this PR adds no serialization code of our own. The two alternatives that work both mean carrying a serializer — hand-written or generated — that has to be kept in step with the DTOs by hand, and a mistake there is a silent wire-format break rather than a compile error. Listing types on a witness class is hard to get wrong.

The trade-off worth your call: `Nerdbank.MessagePack.SignalR` is a third-party package at 1.3.x, by the author of MessagePack-CSharp. If you would rather stay on first-party packages, the hand-written branch above is the drop-in alternative and I am happy to swap this PR over to it.

## Notes

- This PR does **not** add `<PublishAot>` or `<IsAotCompatible>` to any project — it only makes AOT viable. Enabling `IsAotCompatible` on `Tunnelite.Sdk` will surface pre-existing warnings from `Microsoft.AspNetCore.SignalR.Client`; happy to add it here if you want it.
- To publish: `dotnet publish src/Tunnelite.Client -c Release -r <rid> -p:PublishAot=true` (NativeAOT cannot cross-compile, so each RID needs a matching build machine).
