### PR TITLE
Target net10.0 and update the framework packages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.x'
+          dotnet-version: '10.x'
 
       - name: Build with dotnet
         working-directory: src/Tunnelite.Server

--- a/src/Tunnelite.AspNetCore/Tunnelite.AspNetCore.csproj
+++ b/src/Tunnelite.AspNetCore/Tunnelite.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<PackageId>Tunnelite.AspNetCore</PackageId>

--- a/src/Tunnelite.Client/Tunnelite.Client.csproj
+++ b/src/Tunnelite.Client/Tunnelite.Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackAsTool>true</PackAsTool>

--- a/src/Tunnelite.Sdk/Tunnelite.Sdk.csproj
+++ b/src/Tunnelite.Sdk/Tunnelite.Sdk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<PackageId>Tunnelite.Sdk</PackageId>
@@ -26,10 +26,16 @@
 		</None>
 	</ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.10" />
-		<PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.10" />
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.31" />
+		<PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.31" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.12" />
+		<PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.12" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.12" />
 	</ItemGroup>
 
 </Project>

--- a/src/Tunnelite.Server/Tunnelite.Server.csproj
+++ b/src/Tunnelite.Server/Tunnelite.Server.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.10" />
-    <PackageReference Include="Microsoft.Azure.SignalR" Version="1.28.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.12" />
+    <PackageReference Include="Microsoft.Azure.SignalR" Version="1.33.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Test.TcpClient/Test.TcpClient.csproj
+++ b/test/Test.TcpClient/Test.TcpClient.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/test/Test.TcpForwarder/Test.TcpForwarder.csproj
+++ b/test/Test.TcpForwarder/Test.TcpForwarder.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/test/Test.TcpServer/Test.TcpServer.csproj
+++ b/test/Test.TcpServer/Test.TcpServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/test/Test.WebApi/Test.WebApi.csproj
+++ b/test/Test.WebApi/Test.WebApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #4.

.NET 8 (LTS) goes out of support on **2026-11-10**, and .NET 9 (STS) already went out of support on 2026-05-12, so `net10.0` is the only currently serviced target.

### Changes

| | Before | After |
| --- | --- | --- |
| Tunnelite.Client, Tunnelite.Server, test/* | `net8.0` | `net10.0` |
| Tunnelite.Sdk, Tunnelite.AspNetCore | `net8.0` | `net8.0;net10.0` |
| Microsoft.AspNetCore.SignalR.* | 8.0.10 | 10.0.12 (8.0.31 on the net8.0 leg) |
| Microsoft.Extensions.Logging.Console | 8.0.1 | 10.0.12 (8.0.1 on the net8.0 leg) |
| Microsoft.Azure.SignalR | 1.28.0 | 1.33.1 |
| `deploy.yml` setup-dotnet | `8.x` | `10.x` |

The two libraries published to NuGet multi-target so existing consumers on .NET 8 are not forced to move at the same time as you; if you would rather keep it simple and go `net10.0`-only there, say the word and I'll drop that part.

The package bump also clears the restore warning that has been firing on every build:

```
warning NU1903: Package 'Microsoft.AspNetCore.SignalR.Protocols.MessagePack' 8.0.10
has a known high severity vulnerability
```
(GHSA-f8h2-vmm9-qhj6 — gone after the bump.)

### Verification

Built the full solution (`0 Error(s)`, no new warnings — only the two pre-existing `CS0067`s), then ran a `net10.0` server and client against each other:

| Path | Result |
| --- | --- |
| HTTP GET | ok |
| HTTP POST with body | ok |
| SSE streaming | ok |
| WebSocket, bidirectional | ok |
| TCP tunnel, 200 KB file | ok, SHA-1 matches |

`dotnet pack` still produces `lib/net8.0` + `lib/net10.0` for both packages, and the `Tunnelite` tool package builds unchanged.

### Two things worth your call

- **Azure App Service** needs a .NET 10 runtime for `deploy.yml` to keep working. I bumped the workflow SDK, but I cannot see or change the App Service configuration — please make sure the target stack is on .NET 10 before merging, or hold this until it is.
- **`dotnet tool install -g Tunnelite`** will require the .NET 10 SDK once the client targets `net10.0`. That is normal for global tools, but it does raise the floor for existing users — #6 (shipping self-contained binaries) would remove that requirement entirely.

This PR is independent of #7 — they touch different files (`.csproj`/workflow here, `Tunnelite.Sdk/*.cs` there) and can merge in either order.