### PR TITLE
Publish NativeAOT client binaries on tagged releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,111 @@
+name: Release client
+
+on:
+  push:
+    tags: [ 'v*' ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: ${{ matrix.rid }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # NativeAOT cannot cross-compile, so every RID needs a runner of its own.
+          - { os: ubuntu-latest,    rid: linux-x64 }
+          - { os: ubuntu-24.04-arm, rid: linux-arm64 }
+          - { os: macos-13,         rid: osx-x64 }
+          - { os: macos-latest,     rid: osx-arm64 }
+          - { os: windows-latest,   rid: win-x64 }
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.x'
+
+      - name: Publish
+        shell: bash
+        run: >
+          dotnet publish src/Tunnelite.Client
+          -c Release
+          -r ${{ matrix.rid }}
+          -p:PublishAot=true
+          -o publish
+
+      - name: Stage
+        shell: bash
+        run: |
+          set -euo pipefail
+          staging="staging/tunnelite-${{ matrix.rid }}"
+          mkdir -p "$staging" dist
+          # The binary is renamed rather than built as "tunnelite": passing
+          # -p:AssemblyName to the publish above makes the AOT link fail with
+          # "Failed to load type 'Tunnelite.Sdk.ITunnelClient'".
+          if [ -f publish/Tunnelite.Client.exe ]; then
+            cp publish/Tunnelite.Client.exe "$staging/tunnelite.exe"
+          else
+            cp publish/Tunnelite.Client "$staging/tunnelite"
+            chmod +x "$staging/tunnelite"
+          fi
+          cp LICENSE README.md "$staging/"
+
+      - name: Archive (tar.gz)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: tar -czf "dist/tunnelite-${{ matrix.rid }}.tar.gz" -C staging "tunnelite-${{ matrix.rid }}"
+
+      - name: Archive (zip)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Compress-Archive -Path "staging/tunnelite-${{ matrix.rid }}" -DestinationPath "dist/tunnelite-${{ matrix.rid }}.zip"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tunnelite-${{ matrix.rid }}
+          path: dist/*
+          if-no-files-found: error
+
+  release:
+    needs: build
+    # A manual run builds and uploads artifacts but publishes nothing.
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist
+          sha256sum tunnelite-* > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Publish release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${{ github.ref_name }}"
+          if gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            gh release upload "$tag" dist/* --repo "${{ github.repository }}" --clobber
+          else
+            gh release create "$tag" dist/* \
+              --repo "${{ github.repository }}" \
+              --title "$tag" \
+              --generate-notes
+          fi


### PR DESCRIPTION
Fixes #6. Follows #7, which is what made this possible.

Adds `.github/workflows/release.yml`. Pushing a `v*` tag builds the client with NativeAOT on five platforms and attaches the archives to the release for that tag.

```
tunnelite-linux-x64.tar.gz
tunnelite-linux-arm64.tar.gz
tunnelite-osx-x64.tar.gz
tunnelite-osx-arm64.tar.gz
tunnelite-win-x64.zip
SHA256SUMS
```

Each archive holds the single executable named `tunnelite`, plus `LICENSE` and `README.md`. The osx-arm64 one is 4.8 MB compressed for a 17 MB binary.

To cut a release: `git tag v1.1.8 && git push origin v1.1.8`. A manual `workflow_dispatch` run builds and uploads artifacts but publishes nothing, so you can exercise it without creating a release.

### Notes on the shape of it

- **One runner per RID.** NativeAOT cannot cross-compile, so this is a matrix rather than a single job. That is the main cost of the approach — five runners per release instead of one.
- **The binary is renamed, not built under the name.** Passing `-p:AssemblyName=tunnelite` to the publish fails the AOT link with `Failed to load type 'Tunnelite.Sdk.ITunnelClient' from assembly 'tunnelite'`, from a clean tree, on both `net8.0` and `net10.0`. Renaming the produced file works and `--help` still prints `Usage: tunnelite`, since System.CommandLine takes that from the process name. There is a comment in the workflow so nobody 'fixes' it later.
- **No third-party actions.** Only `actions/checkout`, `actions/setup-dotnet`, `actions/upload-artifact`, `actions/download-artifact` and the `gh` CLI, matching what `deploy.yml` already uses. `contents: write` is scoped to the release job.
- Uses the 10.x SDK, in line with `deploy.yml` after #8.

### What I could and could not verify

Verified locally: the YAML parses, the publish command produces a working AOT binary, and the staging/archive/checksum steps run as written — I extracted the resulting `tunnelite-osx-arm64.tar.gz` and tunneled HTTP and a WebSocket through the extracted binary against a local server.

**Not verified: the workflow has never run in CI.** I cannot exercise the other four runners or the release job from here, so treat the first tag as the real test — that is what `workflow_dispatch` is there for. The parts most likely to need a nudge are the `ubuntu-24.04-arm` runner label and the Windows `Compress-Archive` step.

### Deliberately left out

- **Code signing and notarization.** The macOS binaries are unsigned, so Gatekeeper will block them until the user clears the quarantine attribute, and Windows SmartScreen will warn on first run. Fixing that properly needs an Apple Developer ID and a Windows signing certificate, which are yours to hold, not something I can put in a PR. Worth deciding before you point users at the downloads.
- **`win-arm64` and `linux-musl-x64`.** Both are addable — musl needs a container step — but I left them out rather than add runner labels I cannot test.
- **The landing page.** #9 documents `dotnet tool install`, and it is a fresh redesign of yours; I am not touching it in this PR. Once a release exists you may want download links there and in `llms-full.txt`. Happy to send that separately.
- **The `dotnet tool` package.** Unchanged and still the right default for anyone who has the SDK. This is an addition, not a replacement.
