### PR TITLE
Publish NuGet packages from the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release client
+name: Release
 
 on:
   push:
@@ -72,8 +72,73 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
+  nuget:
+    name: NuGet packages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Trusted publishing: the GitHub OIDC token is exchanged for a short-lived NuGet API key,
+      # so no long-lived key is stored in the repository.
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.x'
+
+      - name: Version from tag
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            version="${{ github.ref_name }}"
+            version="${version#v}"
+          else
+            version="0.0.0-ci.${{ github.run_number }}"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Packing version $version"
+
+      - name: Test
+        run: dotnet test test/Tunnelite.Tests -c Release
+
+      - name: Pack
+        shell: bash
+        run: |
+          set -euo pipefail
+          for project in src/Tunnelite.Sdk src/Tunnelite.AspNetCore src/Tunnelite.Client; do
+            dotnet pack "$project" -c Release -p:Version=${{ steps.version.outputs.version }} -o packages
+          done
+          ls -la packages
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: nuget-packages
+          path: packages/*
+          if-no-files-found: error
+
+      # A manual run packs and uploads artifacts but publishes nothing.
+      - name: Log in to NuGet
+        if: startsWith(github.ref, 'refs/tags/')
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: cristipufu
+
+      - name: Push to NuGet
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        run: >
+          dotnet nuget push "packages/*.nupkg"
+          --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+          --source https://api.nuget.org/v3/index.json
+          --skip-duplicate
+
   release:
-    needs: build
+    needs: [build, nuget]
     # A manual run builds and uploads artifacts but publishes nothing.
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
@@ -91,7 +156,7 @@ jobs:
         run: |
           set -euo pipefail
           cd dist
-          sha256sum tunnelite-* > SHA256SUMS
+          sha256sum tunnelite-* *.nupkg > SHA256SUMS
           cat SHA256SUMS
 
       - name: Publish release

--- a/src/Tunnelite.AspNetCore/Tunnelite.AspNetCore.csproj
+++ b/src/Tunnelite.AspNetCore/Tunnelite.AspNetCore.csproj
@@ -13,7 +13,6 @@
 		<Description>SDK for tunneling AspNetCore apps</Description>
 		<PackageProjectUrl>https://github.com/cristipufu/tunnelite</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/cristipufu/tunnelite</RepositoryUrl>
-		<Version>1.0.1</Version>
 		<IsPackable>true</IsPackable>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/Tunnelite.Client/Tunnelite.Client.csproj
+++ b/src/Tunnelite.Client/Tunnelite.Client.csproj
@@ -16,7 +16,6 @@
     <Description>Tool for tunneling URLs</Description>
     <PackageProjectUrl>https://github.com/cristipufu/tunnelite</PackageProjectUrl>
     <RepositoryUrl>https://github.com/cristipufu/tunnelite</RepositoryUrl>
-    <Version>1.1.7</Version>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 	

--- a/src/Tunnelite.Sdk/Tunnelite.Sdk.csproj
+++ b/src/Tunnelite.Sdk/Tunnelite.Sdk.csproj
@@ -13,7 +13,6 @@
 		<Description>SDK for tunneling URLs</Description>
 		<PackageProjectUrl>https://github.com/cristipufu/tunnelite</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/cristipufu/tunnelite</RepositoryUrl>
-		<Version>1.0.0</Version>
 		<IsPackable>true</IsPackable>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>


### PR DESCRIPTION
## Summary

Extends `release.yml` (from #10) so that pushing a `v*` tag also publishes the three NuGet packages, using the trusted publisher configured on nuget.org:

- https://www.nuget.org/packages/Tunnelite/
- https://www.nuget.org/packages/Tunnelite.Sdk/
- https://www.nuget.org/packages/Tunnelite.AspNetCore/

### What the new `nuget` job does
1. Derives the version from the tag (`v1.2.0` → `1.2.0`; a manual run uses `0.0.0-ci.<run>`).
2. Runs the integration test suite.
3. Packs the three projects with `-p:Version=<tag>` and uploads them as an artifact.
4. On a tag only: `NuGet/login@v1` exchanges the job's GitHub OIDC token for a short-lived API key (`id-token: write`), then `dotnet nuget push --skip-duplicate` publishes the `.nupkg` files (symbol packages go along automatically).

The `release` job now waits for both `build` and `nuget`, attaches the packages to the GitHub release next to the binaries, and includes them in `SHA256SUMS`. A manual `workflow_dispatch` run packs and uploads artifacts but publishes nothing, same as for the binaries.

### Versioning
The hardcoded `<Version>` in the three csproj files is removed: the tag is the version, and one tag versions all three packages together, so `Tunnelite` and `Tunnelite.AspNetCore` depend on the `Tunnelite.Sdk` built in the same run. Current versions on nuget.org are Tunnelite 1.1.8, Tunnelite.Sdk 1.0.0, Tunnelite.AspNetCore 1.0.1, so the first tag should be `v1.2.0` or higher.

### Trusted publisher checklist (nuget.org side)
The policy must match this workflow: owner `cristipufu`, repository `tunnelite`, workflow file `release.yml`. If the policy specifies a GitHub environment, add the same `environment:` to the `nuget` job. `user: cristipufu` in the login step is the nuget.org profile that owns the packages.

## Verification
- [x] Packed all three locally with `-p:Version=1.2.0-test`: nuspecs carry the version, MIT license and README; `Tunnelite.AspNetCore` depends on `Tunnelite.Sdk 1.2.0-test`; the tool package ships `Tunnelite.Sdk.dll` and `DotnetToolSettings.xml`
- [x] Workflow YAML parses; `release` needs `[build, nuget]`
- [ ] First real run: push a tag (`git tag v1.2.0 && git push origin v1.2.0`) after the server is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146eTpu2gJNkYPDtMbiSuTC
