### PR TITLE
Release binaries: drop the ICU dependency, and smoke test what gets uploaded

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,16 @@ jobs:
 
       - name: Publish
         shell: bash
+        # InvariantGlobalization keeps the binary from requiring ICU at runtime: without it
+        # a Linux build dies on any image that has no libicu installed, which is most slim
+        # images. It is set here rather than in the csproj so the dotnet tool package keeps
+        # its current behaviour.
         run: >
           dotnet publish src/Tunnelite.Client
           -c Release
           -r ${{ matrix.rid }}
           -p:PublishAot=true
+          -p:InvariantGlobalization=true
           -o publish
 
       - name: Stage
@@ -65,6 +70,18 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: Compress-Archive -Path "staging/tunnelite-${{ matrix.rid }}" -DestinationPath "dist/tunnelite-${{ matrix.rid }}.zip"
+
+      - name: Smoke test
+        shell: bash
+        # Every RID in the matrix matches its runner, so the artifact can be run here.
+        run: |
+          set -euo pipefail
+          staging="staging/tunnelite-${{ matrix.rid }}"
+          if [ -f "$staging/tunnelite.exe" ]; then
+            "$staging/tunnelite.exe" --help
+          else
+            "$staging/tunnelite" --help
+          fi
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Follow-up to #10. I found this while testing the artifacts rather than just building them, and pushed the fix about six minutes after you merged — so it missed the merge. Sorry for the split.

## The problem

The release workflow on master produces Linux binaries that abort at startup on any system without `libicu`:

```
Process terminated. Couldn't find a valid ICU package installed on the system.
   at System.RuntimeExceptionHelpers.FailFast(...)
   at System.Globalization.GlobalizationMode.Settings..cctor()
```

That is not a slim-image edge case — it is stock `ubuntu:24.04` as well as `debian:12-slim`. So as it stands, the first `v*` tag would publish downloads that fail for a good share of the people who are most likely to want a single binary: containers, minimal VMs, CI images.

Reproduced with a **natively built** `linux-x64` binary, produced by the exact publish command on master inside `mcr.microsoft.com/dotnet/sdk:10.0` — not a cross-compiled approximation.

| Image | master's build | with this PR |
| --- | --- | --- |
| `debian:12-slim` | ICU abort | `--help` prints |
| `ubuntu:24.04` | ICU abort | `--help` prints |
| `alpine:3` (musl) | ICU abort | `--help` prints |

## The fix

Publish with `-p:InvariantGlobalization=true`. Passed on the publish command rather than set in `Tunnelite.Client.csproj`, so the `dotnet tool` package keeps its current behaviour and only the standalone binaries change. The binary also gets slightly smaller (12,703,640 → 12,509,976 bytes).

The trade-off is real but small for this tool: culture-sensitive formatting and comparison become invariant. The client formats timestamps with `HH:mm:ss` and compares URL schemes ordinally, so nothing here depends on a culture. If you would rather keep full globalization, the alternative is to document a `libicu` requirement for the Linux downloads — but that gives up much of the point of shipping a self-contained binary.

## Also: smoke test the artifact

Runs `tunnelite --help` on the packaged binary before uploading it. Every RID in the matrix matches its runner, so it costs a second and no extra infrastructure.

This is the check that would have caught the above. The workflow was green in the sense that everything *built*; the binary was simply broken. Worth having, since nobody is going to manually download five archives before every release.