### PR TITLE
Add test-count, CD and NuGet badges to the README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
   test:
     name: Build and test
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # pushes the test-count badge data to the "badges" branch on master
 
     steps:
       - uses: actions/checkout@v4
@@ -37,6 +39,39 @@ jobs:
         with:
           name: test-results
           path: TestResults
+
+      # The README "tests" badge reads badges/tests.json (shields.io endpoint format).
+      - name: Test count for the README badge
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          counters=$(grep -o '<Counters [^/]*/>' TestResults/tests.trx | head -1)
+          total=$(sed -n 's/.* total="\([0-9]*\)".*/\1/p' <<<"$counters")
+          passed=$(sed -n 's/.* passed="\([0-9]*\)".*/\1/p' <<<"$counters")
+          failed=$(sed -n 's/.* failed="\([0-9]*\)".*/\1/p' <<<"$counters")
+          if [[ "${failed:-0}" == "0" && "$passed" == "$total" ]]; then
+            message="$passed passed"; color=brightgreen
+          else
+            message="$failed failed / $total"; color=red
+          fi
+          mkdir -p badge
+          printf '{"schemaVersion":1,"label":"tests","message":"%s","color":"%s"}\n' "$message" "$color" > badge/tests.json
+          cat badge/tests.json
+
+      - name: Publish the badge data
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/master'
+        shell: bash
+        run: |
+          set -euo pipefail
+          [ -f badge/tests.json ] || exit 0
+          cd badge
+          git init -q -b badges
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add tests.json
+          git commit -q -m "tests badge: $(cat tests.json)"
+          git push -q --force "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git" badges
 
   native-aot:
     name: NativeAOT client

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # ⚡Tunnelite
 
-[![CI](https://github.com/cristipufu/tunnelite/actions/workflows/ci.yml/badge.svg)](https://github.com/cristipufu/tunnelite/actions/workflows/ci.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/cristipufu/tunnelite/ci.yml?branch=master&label=CI&logo=github)](https://github.com/cristipufu/tunnelite/actions/workflows/ci.yml)
+[![Tests](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcristipufu%2Ftunnelite%2Fbadges%2Ftests.json&logo=xunit)](https://github.com/cristipufu/tunnelite/actions/workflows/ci.yml)
+[![CD](https://img.shields.io/github/actions/workflow/status/cristipufu/tunnelite/deploy.yml?branch=master&label=CD&logo=microsoftazure)](https://github.com/cristipufu/tunnelite/actions/workflows/deploy.yml)
+[![NuGet](https://img.shields.io/nuget/v/Tunnelite?logo=nuget&label=NuGet)](https://www.nuget.org/packages/Tunnelite/)
+[![NuGet downloads](https://img.shields.io/nuget/dt/Tunnelite?logo=nuget&label=downloads)](https://www.nuget.org/packages/Tunnelite/)
 
 Tunnelite is a .NET tool that lets you set up a secure connection between a public web address and an application running on your local machine. It effectively makes your local app accessible from the internet.
 


### PR DESCRIPTION
## Summary

README badges:

| Badge | Source |
| --- | --- |
| CI | workflow status of `ci.yml` on master |
| Tests (e.g. "26 passed") | `badges/tests.json` in shields.io endpoint format, written by CI |
| CD | workflow status of `deploy.yml` (the Azure server deployment) on master |
| NuGet version, NuGet downloads | shields.io NuGet badges for `Tunnelite` |

### How the test count gets there
The CI `test` job parses the `<Counters>` element of the TRX report (total / passed / failed). On pushes to master it commits `tests.json` to an orphan `badges` branch (single commit, force-pushed each run, using the job's own token; `contents: write` is scoped to that job and the step only runs for master pushes). Green: "N passed"; red: "N failed / total". The branch is seeded with the current count so the badge renders as soon as this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146eTpu2gJNkYPDtMbiSuTC