### PR TITLE
Pass WebSocket subprotocols through the tunnel

### DIFF
--- a/src/Tunnelite.Sdk/HttpTunnel/HttpConnection.cs
+++ b/src/Tunnelite.Sdk/HttpTunnel/HttpConnection.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 namespace Tunnelite.Sdk;
 
 public class HttpConnection
@@ -13,6 +13,12 @@ public class WsConnection
 {
     public Guid RequestId { get; set; }
     public string Path { get; set; }
+
+    /// <summary>
+    /// Subprotocols the public client asked for; requested from the local app as well. Null from servers that
+    /// predate the field.
+    /// </summary>
+    public string[] SubProtocols { get; set; }
 }
 
 public class SseConnection : HttpConnection

--- a/src/Tunnelite.Sdk/HttpTunnel/HttpTunnelClient.cs
+++ b/src/Tunnelite.Sdk/HttpTunnel/HttpTunnelClient.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.AspNetCore.SignalR.Client;
 using Nerdbank.MessagePack;
 using Nerdbank.MessagePack.SignalR;
 using Microsoft.Extensions.DependencyInjection;
@@ -216,6 +216,12 @@ public class HttpTunnelClient : ITunnelClient, IAsyncDisposable
         try
         {
             using var webSocket = new ClientWebSocket();
+
+            // Ask the local app for the same subprotocols the public client asked for (e.g. Vite's "vite-hmr").
+            foreach (var subProtocol in wsConnection.SubProtocols ?? [])
+            {
+                webSocket.Options.AddSubProtocol(subProtocol);
+            }
 
             await webSocket.ConnectAsync(new Uri(wsConnection.Path), cts.Token);
 

--- a/src/Tunnelite.Server/WsTunnel/WsConnection.cs
+++ b/src/Tunnelite.Server/WsTunnel/WsConnection.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 namespace Tunnelite.Server.WsTunnel;
 
 public class WsConnection
@@ -6,4 +6,10 @@ public class WsConnection
     public Guid RequestId { get; set; }
 
     public string Path { get; set; }
+
+    /// <summary>
+    /// Subprotocols the public client asked for (<c>Sec-WebSocket-Protocol</c>), so the tunnel client can request
+    /// the same ones from the local app. Null when none were requested; older clients ignore the field.
+    /// </summary>
+    public string[] SubProtocols { get; set; }
 }

--- a/src/Tunnelite.Server/WsTunnel/WsTunnelMiddleware.cs
+++ b/src/Tunnelite.Server/WsTunnel/WsTunnelMiddleware.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.SignalR;
+using Microsoft.AspNetCore.SignalR;
 using Tunnelite.Server.HttpTunnel;
 
 namespace Tunnelite.Server.WsTunnel;
@@ -10,6 +10,8 @@ public class WsTunnelMiddleware(RequestDelegate next, WsRequestsQueue requestsQu
     private readonly WsRequestsQueue _requestsQueue = requestsQueue;
     private readonly IHubContext<HttpTunnelHub> _hubContext = hubContext;
     private readonly ILogger<WsTunnelMiddleware> _logger = logger;
+
+    private const int MaxSubProtocols = 8;
 
     public async Task InvokeAsync(HttpContext context)
     {
@@ -59,9 +61,14 @@ public class WsTunnelMiddleware(RequestDelegate next, WsRequestsQueue requestsQu
 
         var requestId = Guid.NewGuid();
 
+        // Browsers drop the connection when a subprotocol they asked for isn't confirmed (Vite's HMR client asks
+        // for "vite-hmr"), so confirm the first one here and pass the whole list on to the tunnel client, which
+        // requests the same from the local app. The list is attacker-controlled input from the public side; cap it.
+        var subProtocols = context.WebSockets.WebSocketRequestedProtocols.Take(MaxSubProtocols).ToArray();
+
         try
         {
-            using var webSocket = await context.WebSockets.AcceptWebSocketAsync();
+            using var webSocket = await context.WebSockets.AcceptWebSocketAsync(subProtocols.FirstOrDefault());
 
             _logger.LogInformation("WebSocket connection accepted: {requestId}", requestId);
 
@@ -71,6 +78,7 @@ public class WsTunnelMiddleware(RequestDelegate next, WsRequestsQueue requestsQu
             {
                 RequestId = requestId,
                 Path = $"{ConvertHttpToWsUri(tunnel.LocalUrl)}{path}{context.Request.QueryString}",
+                SubProtocols = subProtocols.Length > 0 ? subProtocols : null,
             });
 
             await completionTask;

--- a/test/Tunnelite.Tests/HttpTunnelTests.cs
+++ b/test/Tunnelite.Tests/HttpTunnelTests.cs
@@ -203,6 +203,39 @@ public class HttpTunnelTests(TunnelHost host) : IClassFixture<TunnelHost>
     }
 
     [Fact]
+    public async Task WebSocket_subprotocol_is_negotiated_with_the_local_app()
+    {
+        // Vite's HMR client asks for "vite-hmr" and gives up unless the server confirms it; the local app only
+        // accepts the connection when it is asked for. Both sides of the tunnel have to pass it through.
+        using var cts = new CancellationTokenSource(TestData.Timeout);
+        using var socket = new ClientWebSocket();
+        socket.Options.AddSubProtocol("vite-hmr");
+
+        await socket.ConnectAsync(new Uri(host.PublicUrl.Replace("http://", "ws://") + "/ws"), cts.Token);
+
+        Assert.Equal("vite-hmr", socket.SubProtocol);
+
+        await socket.SendAsync(Encoding.UTF8.GetBytes("subprotocol?"), WebSocketMessageType.Text, true, cts.Token);
+        var (data, _) = await TestData.ReceiveMessageAsync(socket, cts.Token);
+
+        Assert.Equal("vite-hmr", Encoding.UTF8.GetString(data));
+    }
+
+    [Fact]
+    public async Task WebSocket_without_a_subprotocol_stays_without_one()
+    {
+        using var cts = new CancellationTokenSource(TestData.Timeout);
+        using var socket = await ConnectWebSocketAsync("/ws", cts.Token);
+
+        Assert.Null(socket.SubProtocol);
+
+        await socket.SendAsync(Encoding.UTF8.GetBytes("subprotocol?"), WebSocketMessageType.Text, true, cts.Token);
+        var (data, _) = await TestData.ReceiveMessageAsync(socket, cts.Token);
+
+        Assert.Equal("(none)", Encoding.UTF8.GetString(data));
+    }
+
+    [Fact]
     public async Task WebSocket_close_from_the_public_client_completes_the_handshake_without_errors()
     {
         var failuresBefore = host.ClientFailures.Count;

--- a/test/Tunnelite.Tests/Infrastructure/LocalApp.cs
+++ b/test/Tunnelite.Tests/Infrastructure/LocalApp.cs
@@ -77,7 +77,8 @@ public sealed class LocalApp : IAsyncDisposable
             }
         });
 
-        // Echo every frame back exactly as received: same type, same end-of-message flag.
+        // Echo every frame back exactly as received: same type, same end-of-message flag. Accepts the first
+        // subprotocol the client asks for (like Vite's HMR server does) and reports it when asked "subprotocol?".
         app.Map("/ws", async (HttpContext context) =>
         {
             if (!context.WebSockets.IsWebSocketRequest)
@@ -86,7 +87,7 @@ public sealed class LocalApp : IAsyncDisposable
                 return;
             }
 
-            using var socket = await context.WebSockets.AcceptWebSocketAsync();
+            using var socket = await context.WebSockets.AcceptWebSocketAsync(context.WebSockets.WebSocketRequestedProtocols.FirstOrDefault());
             var buffer = new byte[64 * 1024];
 
             while (socket.State == WebSocketState.Open)
@@ -97,6 +98,14 @@ public sealed class LocalApp : IAsyncDisposable
                 {
                     await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "echo done", CancellationToken.None);
                     break;
+                }
+
+                if (result.MessageType == WebSocketMessageType.Text && result.EndOfMessage
+                    && System.Text.Encoding.UTF8.GetString(buffer, 0, result.Count) == "subprotocol?")
+                {
+                    var answer = System.Text.Encoding.UTF8.GetBytes(socket.SubProtocol ?? "(none)");
+                    await socket.SendAsync(answer, WebSocketMessageType.Text, true, context.RequestAborted);
+                    continue;
                 }
 
                 await socket.SendAsync(new ArraySegment<byte>(buffer, 0, result.Count), result.MessageType, result.EndOfMessage, context.RequestAborted);


### PR DESCRIPTION
## Summary

Found while tunneling a Vite dev server: the page loaded, but Vite's HMR WebSocket failed with "[vite] failed to connect to websocket".

Browsers drop a WebSocket when a subprotocol they asked for (`Sec-WebSocket-Protocol`) is not confirmed by the server, and Vite's HMR server only accepts the upgrade when `vite-hmr` is requested. The tunnel confirmed nothing on the public side and requested nothing from the local app, so both ends refused. A raw handshake shows it: Vite answers `101` with `Sec-WebSocket-Protocol: vite-hmr`, the tunnel answered `101` without it.

### Change
- **Server** (`WsTunnelMiddleware`): accepts the public socket with the first requested subprotocol and sends the requested list (capped at 8, since it is public input) to the client as `WsConnection.SubProtocols`.
- **SDK** (`HttpTunnelClient`): requests the same subprotocols from the local app.
- Compatible both ways: clients built before the field ignore the extra map key; a server without it leaves the field null and the client behaves as before.

### Tests
- `WebSocket_subprotocol_is_negotiated_with_the_local_app`: the public client asks for `vite-hmr`, asserts the server confirmed it, then asks the local app which subprotocol it negotiated and gets `vite-hmr` back. Fails if either half of the fix is reverted (checked both).
- `WebSocket_without_a_subprotocol_stays_without_one`.

28 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146eTpu2gJNkYPDtMbiSuTC