### PR TITLE
Fix the landing page layout on phones

### DIFF
--- a/src/Tunnelite.Server/wwwroot/index.html
+++ b/src/Tunnelite.Server/wwwroot/index.html
@@ -200,6 +200,7 @@
         :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 6px; }
 
         .container { max-width: 1120px; margin: 0 auto; padding: 0 24px; }
+        .hero-copy, .hero-demo, .feature, .card, .code-block, .terminal, .install-list { min-width: 0; }
 
         .skip-link {
             position: absolute; left: -999px; top: 8px; z-index: 100;
@@ -275,7 +276,7 @@
         }
         .hero-grid {
             position: relative;
-            display: grid; grid-template-columns: 1.05fr .95fr; gap: 64px; align-items: center;
+            display: grid; grid-template-columns: minmax(0, 1.05fr) minmax(0, .95fr); gap: 64px; align-items: center;
         }
         .badge {
             display: inline-flex; align-items: center; gap: 8px;
@@ -299,13 +300,13 @@
         .lead { font-size: var(--fs-18); line-height: 1.55; color: var(--muted); max-width: 52ch; margin: 0 0 32px; }
         .hero-actions { display: flex; flex-wrap: wrap; gap: 12px; margin-bottom: 32px; }
         .hero-install {
-            display: inline-flex; align-items: center; gap: 12px; max-width: 100%;
+            display: flex; align-items: center; gap: 12px; width: fit-content; max-width: 100%;
             padding: 8px 8px 8px 16px; border-radius: var(--radius-md);
             border: 1px solid var(--code-edge); background: var(--code-bg);
             box-shadow: var(--shadow-md);
             font-family: var(--mono); font-size: var(--fs-14);
         }
-        .hero-install code { white-space: nowrap; overflow: auto; color: var(--code-text); }
+        .hero-install code { min-width: 0; white-space: nowrap; overflow-x: auto; color: var(--code-text); }
 
         /* ---------- Terminal ---------- */
         .terminal {
@@ -361,7 +362,7 @@
         .narrow { max-width: 760px; }
 
         /* Features */
-        .features-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 20px; }
+        .features-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 20px; }
         .feature {
             padding: 24px; border-radius: var(--radius-lg);
             border: 1px solid var(--border);
@@ -420,7 +421,7 @@
         .note { color: var(--muted); font-size: var(--fs-15); margin: 16px 0 0; }
 
         /* Self-hosting */
-        .selfhost-grid { display: grid; grid-template-columns: 1.25fr .75fr; gap: 20px; align-items: start; }
+        .selfhost-grid { display: grid; grid-template-columns: minmax(0, 1.25fr) minmax(0, .75fr); gap: 20px; align-items: start; }
         .card {
             padding: 32px; border-radius: var(--radius-lg);
             border: 1px solid var(--border);
@@ -490,22 +491,25 @@
         /* ---------- Responsive ---------- */
         @media (max-width: 1000px) {
             .hero { padding: 64px 0; }
-            .hero-grid { grid-template-columns: 1fr; gap: 40px; }
+            .hero-grid { grid-template-columns: minmax(0, 1fr); gap: 40px; }
             .terminal-body { min-height: 0; }
-            .features-grid { grid-template-columns: repeat(2, 1fr); }
+            .features-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
         }
         @media (max-width: 860px) {
             .nav-links { display: none; }
         }
         @media (max-width: 760px) {
-            .selfhost-grid { grid-template-columns: 1fr; }
+            .selfhost-grid { grid-template-columns: minmax(0, 1fr); }
         }
         @media (max-width: 600px) {
             .section { padding: 64px 0; }
             .section-head { margin-bottom: 32px; }
-            .features-grid { grid-template-columns: 1fr; }
+            .features-grid { grid-template-columns: minmax(0, 1fr); }
             .card { padding: 24px; }
             .hero-actions .btn { flex: 1; justify-content: center; }
+            .hero-install { width: 100%; }
+            .hero-install code { white-space: pre-wrap; word-break: break-all; }
+            .code-block pre { white-space: pre-wrap; word-break: break-all; }
             .btn-sm span { display: none; }
         }
         @media (prefers-reduced-motion: reduce) {

--- a/src/Tunnelite.Server/wwwroot/index.html
+++ b/src/Tunnelite.Server/wwwroot/index.html
@@ -414,6 +414,16 @@
         .copy-btn.copied .ico-copy { display: none; }
         .copy-btn.copied .ico-check { display: block; }
         .install-list { display: grid; gap: 16px; max-width: 760px; }
+        .install-standalone {
+            display: flex; align-items: center; justify-content: space-between; gap: 20px; flex-wrap: wrap;
+            max-width: 760px; margin-top: 20px; padding: 20px 24px;
+            border: 1px solid var(--border); border-radius: var(--radius-lg);
+            background: var(--surface); box-shadow: var(--shadow-sm);
+        }
+        .install-standalone > div { min-width: 0; flex: 1 1 320px; }
+        .install-standalone h3 { margin: 0 0 4px; font-size: var(--fs-17); line-height: 1.35; font-weight: 600; letter-spacing: -.01em; }
+        .install-standalone p { color: var(--muted); font-size: var(--fs-15); line-height: 1.6; }
+        .install-standalone .btn { flex: none; }
         .inline {
             font-family: var(--mono); font-size: .9em; padding: 2px 6px; border-radius: 6px;
             background: rgba(15, 23, 42, .06); border: 1px solid var(--border); color: var(--text);
@@ -673,6 +683,16 @@
                         </div>
                         <pre><code>#tool dotnet:?package=Tunnelite</code></pre>
                     </div>
+                </div>
+                <div class="install-standalone">
+                    <div>
+                        <h3>Standalone binaries</h3>
+                        <p>Every release also ships a single self-contained executable for Linux, macOS and Windows that needs no .NET runtime installed.</p>
+                    </div>
+                    <a class="btn btn-ghost" href="https://github.com/cristipufu/tunnelite/releases/latest" target="_blank" rel="noopener noreferrer">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="M7 10l5 5 5-5"/><path d="M12 15V3"/></svg>
+                        Download from GitHub Releases
+                    </a>
                 </div>
             </div>
         </section>

--- a/src/Tunnelite.Server/wwwroot/llms-full.txt
+++ b/src/Tunnelite.Server/wwwroot/llms-full.txt
@@ -43,6 +43,8 @@ Update an existing installation:
 
     dotnet tool update --global Tunnelite
 
+Standalone binaries: every GitHub release (https://github.com/cristipufu/tunnelite/releases/latest) also ships a single self-contained executable, built with NativeAOT, that needs no .NET runtime: tunnelite-linux-x64.tar.gz, tunnelite-linux-arm64.tar.gz, tunnelite-osx-x64.tar.gz, tunnelite-osx-arm64.tar.gz and tunnelite-win-x64.zip, plus a SHA256SUMS file.
+
 ## Usage
 
 Create a tunnel to a local HTTP application:

--- a/src/Tunnelite.Server/wwwroot/llms.txt
+++ b/src/Tunnelite.Server/wwwroot/llms.txt
@@ -15,6 +15,7 @@ Typical use cases: exposing locally-hosted web apps for testing or demos, testin
 
 - [GitHub repository](https://github.com/cristipufu/tunnelite): MIT-licensed source for the CLI, SDK, ASP.NET Core integration and server
 - [Tunnelite on NuGet](https://www.nuget.org/packages/Tunnelite): The `tunnelite` command-line tool
+- [GitHub Releases](https://github.com/cristipufu/tunnelite/releases/latest): Standalone `tunnelite` executables for Linux, macOS and Windows, no .NET runtime needed
 - [Tunnelite.Sdk on NuGet](https://www.nuget.org/packages/Tunnelite.Sdk): .NET library with HttpTunnelClient and TcpTunnelClient
 - [Tunnelite.AspNetCore on NuGet](https://www.nuget.org/packages/Tunnelite.AspNetCore): `app.UseTunnelite()` middleware that tunnels an ASP.NET Core app on startup
 


### PR DESCRIPTION
## Summary

On phones (iOS Safari and Chrome) tunnelite.com laid out wider than the screen, so the browser zoomed out and the right side was cut off. CSS only, three causes:

1. The install command chip (`.hero-install code`) was `white-space: nowrap` inside a flex container with no `min-width: 0`, so the chip grew to the width of the command and dragged the hero column with it.
2. All grids used bare `1fr` tracks, which expand to the widest unbreakable child. The long `--publicUrl` command made the self-hosting column 589 px wide at a 375 px viewport.
3. Code blocks and cards had no `min-width: 0`, so their `overflow-x: auto` never took effect.

### Fix
- Grid tracks are `minmax(0, 1fr)`; grid and flex children get `min-width: 0`.
- The install chip fits its container and the command scrolls inside it; on screens up to 600 px the chip and the code blocks wrap instead of scrolling, so nothing is hidden.

### Verification
Rendered the page inside a 375 px and a 320 px frame (Chrome can't shrink a window below ~500 px, which is how the earlier check missed this) and listed every element extending past the viewport: none on the landing page, none on the 404/500 pages. Before the fix, 49 elements overflowed at 375 px and the document was 613 px wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146eTpu2gJNkYPDtMbiSuTC

### Also in this PR
The Installation section now has a "Standalone binaries" block linking to the GitHub releases page, since every release ships self-contained executables. `llms.txt` and `llms-full.txt` mention them as well. Checked at 375 px: still no overflow.
