### PR TITLE
Stream local responses through the tunnel instead of buffering them

### DIFF
--- a/src/Tunnelite.Sdk/HttpTunnel/HttpTunnelClient.cs
+++ b/src/Tunnelite.Sdk/HttpTunnel/HttpTunnelClient.cs
@@ -165,8 +165,9 @@ public class HttpTunnelClient : ITunnelClient, IAsyncDisposable
                 localRequest.Content.Headers.ContentType = MediaTypeHeaderValue.Parse(httpConnection.ContentType);
             }
 
-            // Send the request to the local server and get the response
-            using var localResponse = await LocalHttpClient.SendAsync(localRequest);
+            // Send the request to the local server; start forwarding as soon as the headers are in instead of
+            // buffering the whole body first.
+            using var localResponse = await LocalHttpClient.SendAsync(localRequest, HttpCompletionOption.ResponseHeadersRead);
 
             // Prepare the request back to the public server
             using var publicRequest = new HttpRequestMessage(HttpMethod.Post, requestUrl);


### PR DESCRIPTION
## Summary

Two things were tried for the HTTP path after enabling HTTP/2 on the App Service; only one survived the measurements.

### Kept: stream the local response
`LocalHttpClient.SendAsync` used the default completion option, so the CLI read the entire local response body into memory before starting the POST back to the server. It now uses `ResponseHeadersRead` and forwards while the local app is still writing. This is about memory and correctness for large downloads, not speed: with the local app on localhost the buffering took milliseconds, and the numbers below show no timing difference, as expected.



### Dropped: HTTP/2 to the server
The App Service now negotiates HTTP/2 (`http20Enabled` was switched on). A client configured with `DefaultRequestVersion = 2.0` was measured side by side with the released 1.2.1 client (HTTP/1.1) and a streaming-only build, all three tunneling the same local app through tunnelite.com at the same time, from Bucharest to the East US instance:

| | HTTP/1.1 (1.2.1) | streaming only | streaming + HTTP/2 |
| --- | --- | --- | --- |
| /hello, sequential, median first byte | 0.96 s | | 1.00 s |
| /hello, 6 in parallel, wall | 1.05 to 1.58 s | | 1.18 to 1.78 s |
| 1 MB response, total | 2.0 to 2.5 s | 2.0 to 2.5 s | 2.1 to 2.3 s |
| 5 MB response, total | 4.8 to 18 s | 10 to 12 s | 10 to 13.5 s |

With a warm connection pool HTTP/1.1 already reuses its connections, so the handshake saving only exists for the first burst after start, and everything else is the tunnel's round trips and upload bandwidth. HTTP/2 through the App Service front door was, if anything, a hair slower, so the client stays on HTTP/1.1. The server-side toggle is left on: it costs nothing and lets browsers multiplex their own requests to the public URL.

28 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146eTpu2gJNkYPDtMbiSuTC
