### PR TITLE
Stamp the tag version into release binaries and test --version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,20 @@ jobs:
         with:
           dotnet-version: '10.x'
 
+      - name: Version from tag
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            version="${{ github.ref_name }}"
+            version="${version#v}"
+          else
+            version="0.0.0-ci.${{ github.run_number }}"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Building version $version"
+
       - name: Publish
         shell: bash
         # InvariantGlobalization keeps the binary from requiring ICU at runtime: without it
@@ -42,6 +56,7 @@ jobs:
           -r ${{ matrix.rid }}
           -p:PublishAot=true
           -p:InvariantGlobalization=true
+          -p:Version=${{ steps.version.outputs.version }}
           -o publish
 
       - name: Stage

--- a/test/Tunnelite.Tests/CliTests.cs
+++ b/test/Tunnelite.Tests/CliTests.cs
@@ -28,6 +28,26 @@ public sealed class CliFactAttribute : FactAttribute
 public class CliTests(BareTunnelHost host) : IClassFixture<BareTunnelHost>
 {
     [CliFact]
+    public async Task The_cli_binary_reports_its_version()
+    {
+        var cli = Environment.GetEnvironmentVariable(CliFactAttribute.EnvironmentVariable)!;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        using var process = Process.Start(new ProcessStartInfo(cli, "--version")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        })!;
+        var stdout = (await process.StandardOutput.ReadToEndAsync(cts.Token)).Trim();
+        var stderr = await process.StandardError.ReadToEndAsync(cts.Token);
+        await process.WaitForExitAsync(cts.Token);
+
+        Assert.True(process.ExitCode == 0, $"--version exited with {process.ExitCode}: {stderr}");
+        Assert.Matches(@"^\d+\.\d+\.\d+", stdout);
+    }
+
+    [CliFact]
     public async Task The_cli_binary_tunnels_http_sse_and_websockets()
     {
         var cli = Environment.GetEnvironmentVariable(CliFactAttribute.EnvironmentVariable)!;


### PR DESCRIPTION
## Summary
- `tunnelite --version` and `--help` already work (System.CommandLine defaults), but the release `build` job published the NativeAOT binaries without `-p:Version`, so downloaded releases printed `1.0.0+<sha>`. The job now derives the version from the tag (same logic as the NuGet job) and passes it to `dotnet publish`.
- New CLI test `The_cli_binary_reports_its_version` asserts `--version` exits 0 and prints a semantic version. It carries the `Cli` category, so CI runs it against both the regular build and the NativeAOT publish.

## Verification
Local NativeAOT publish on macOS arm64 with `-p:Version=9.9.9` prints `9.9.9+5ec0b49...`; both CLI tests pass against that binary.

This is a prerequisite for a homebrew-core formula, whose `test do` block needs an offline command to check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146eTpu2gJNkYPDtMbiSuTC